### PR TITLE
Add recursive interface generation

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
@@ -25,7 +25,6 @@ class OperationTypeSpecBuilder(
     val nonScalarFields = fields.filter { it.fields?.any() ?: false }
     nonScalarFields.forEach {
       val fieldType = "$typeNamePrefix${it.toTypeName()}"
-
       val existingMapping = typeToFieldMap[fieldType]
       if (existingMapping != null && it.fields != existingMapping.fields) {
         // If we already saw this type and it has a different set of fields, it means
@@ -49,17 +48,11 @@ class OperationTypeSpecBuilder(
       }
     }
 
-    val resultTypeSpecs = ArrayList<TypeSpec>()
-    resultTypeSpecs.add(
-      TypeSpec.interfaceBuilder(currentTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addMethods(fields.map { it.toMethodSpec(fieldToTypeMap[it]) })
-        .build()
-    )
+    val typeSpec = TypeSpec.interfaceBuilder(currentTypeName)
+      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+      .addMethods(fields.map { it.toMethodSpec(fieldToTypeMap[it]) })
+      .build()
 
-    return typeToFieldMap.toList().fold(resultTypeSpecs) { typeSpecs, it ->
-      typeSpecs.addAll(buildTypeSpecs(it.first, it.second.fields!!, it.first))
-      typeSpecs
-    }
+    return listOf(typeSpec) + typeToFieldMap.flatMap { buildTypeSpecs(it.key, it.value.fields!!, it.key) }
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
@@ -24,7 +24,7 @@ class OperationTypeSpecBuilder(
     val typeToFieldMap = HashMap<String, Field>()
     val nonScalarFields = fields.filter { it.fields?.any() ?: false }
     nonScalarFields.forEach {
-      val fieldType = "$typeNamePrefix${it.type.normalizeTypeName()}"
+      val fieldType = "$typeNamePrefix${it.toTypeName()}"
 
       val existingMapping = typeToFieldMap[fieldType]
       if (existingMapping != null && it.fields != existingMapping.fields) {
@@ -34,12 +34,12 @@ class OperationTypeSpecBuilder(
         // used more than once. We also need to use the explicit naming for the previously
         // seen type, so we need to also remove it and re-add with the explicit naming.
 
-        val fieldNewType = "$typeNamePrefix${it.toTypeName()}"
+        val fieldNewType = "$typeNamePrefix${it.toTypeName(it.responseName)}"
         typeToFieldMap.put(fieldNewType, it)
         fieldToTypeMap.put(it, fieldNewType)
 
-        val existingFieldType = "$typeNamePrefix${it.type.normalizeTypeName()}"
-        val existingFieldNewType = "$typeNamePrefix${existingMapping.toTypeName()}"
+        val existingFieldType = "$typeNamePrefix${it.toTypeName()}"
+        val existingFieldNewType = "$typeNamePrefix${existingMapping.toTypeName(existingMapping.responseName)}"
         typeToFieldMap.put(existingFieldNewType, existingMapping)
         typeToFieldMap.remove(existingFieldType)
         fieldToTypeMap.put(existingMapping, existingFieldNewType)
@@ -62,6 +62,4 @@ class OperationTypeSpecBuilder(
       typeSpecs
     }
   }
-
-  private fun String.normalizeTypeName() = removeSuffix("!").removePrefix("[").removeSuffix("]").removeSuffix("!")
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
@@ -1,7 +1,7 @@
 package com.apollostack.compiler.ir
 
 class Field(val responseName: String, val fieldName: String, val type: String,
-    val fields: List<Field>) {
+    val fields: List<Field>?) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other?.javaClass != javaClass) return false

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Operation.kt
@@ -1,6 +1,6 @@
 package com.apollostack.compiler.ir
 
-class Operation(val operationName: String, val operationType: String, val variables: List<String>,
+class Operation(val operationName: String, val operationType: String, val variables: List<Variable>,
     val source: String, val fields: List<Field>) {
 
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/QueryIntermediateRepresentation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/QueryIntermediateRepresentation.kt
@@ -3,4 +3,5 @@ package com.apollostack.compiler.ir
 data class QueryIntermediateRepresentation(
     val operations: List<Operation>,
     val fragments: List<String>,
-    val typesUsed: List<String>)
+    val typesUsed: List<String>
+)

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Variable.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Variable.kt
@@ -1,3 +1,6 @@
 package com.apollostack.compiler.ir
 
-data class Variable(val name:String, val type:String)
+data class Variable(
+  val name:String,
+  val type:String
+)

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Variable.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Variable.kt
@@ -1,0 +1,3 @@
+package com.apollostack.compiler.ir
+
+data class Variable(val name:String, val type:String)

--- a/apollo-compiler/src/test/data/HeroDetails.json
+++ b/apollo-compiler/src/test/data/HeroDetails.json
@@ -1,0 +1,66 @@
+{
+  "operations": [
+    {
+      "operationName": "HeroDetails",
+      "operationType": "query",
+      "variables": [],
+      "source": "query HeroDetails {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      totalCount\n      edges {\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+      "fields": [
+        {
+          "responseName": "hero",
+          "fieldName": "hero",
+          "type": "Character",
+          "fields": [
+            {
+              "responseName": "name",
+              "fieldName": "name",
+              "type": "String!"
+            },
+            {
+              "responseName": "friendsConnection",
+              "fieldName": "friendsConnection",
+              "type": "FriendsConnection!",
+              "fields": [
+                {
+                  "responseName": "totalCount",
+                  "fieldName": "totalCount",
+                  "type": "Int"
+                },
+                {
+                  "responseName": "edges",
+                  "fieldName": "edges",
+                  "type": "[FriendsEdge]",
+                  "fields": [
+                    {
+                      "responseName": "node",
+                      "fieldName": "node",
+                      "type": "Character",
+                      "fields": [
+                        {
+                          "responseName": "name",
+                          "fieldName": "name",
+                          "type": "String!"
+                        }
+                      ],
+                      "fragmentSpreads": [],
+                      "inlineFragments": []
+                    }
+                  ],
+                  "fragmentSpreads": [],
+                  "inlineFragments": []
+                }
+              ],
+              "fragmentSpreads": [],
+              "inlineFragments": []
+            }
+          ],
+          "fragmentSpreads": [],
+          "inlineFragments": []
+        }
+      ],
+      "fragmentsReferenced": []
+    }
+  ],
+  "fragments": [],
+  "typesUsed": []
+}

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -64,6 +64,7 @@ public interface TwoHeroes {
       """package test;
 
 import java.lang.String;
+import java.util.List;
 
 public interface HeroDetails {
   Character hero();
@@ -77,7 +78,7 @@ public interface HeroDetails {
   interface CharacterFriendsConnection {
     int totalCount();
 
-    CharacterFriendsConnectionFriendsEdge edges();
+    List<CharacterFriendsConnectionFriendsEdge> edges();
   }
 
   interface CharacterFriendsConnectionFriendsEdge {

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -55,4 +55,45 @@ interface TwoHeroes {
         .that(listOf(source))
         .compilesWithoutError()
   }
+
+  @Test fun heroDetails() {
+    val compiler = GraphqlCompiler()
+    compiler.write("src/test/data/HeroDetails.json")
+    val outputFile = File("build/generated/source/apollo/test/HeroDetails.java")
+    assertThat(outputFile.readText()).isEqualTo(
+      """package test;
+
+import java.lang.String;
+import java.util.List;
+
+interface HeroDetails {
+  Character hero();
+
+  interface Character {
+    String name();
+
+    FriendsConnection friendsConnection();
+
+    interface FriendsConnection {
+      int totalCount();
+
+      List<FriendsEdge> edges();
+
+      interface FriendsEdge {
+        Character node();
+
+        interface Character {
+          String name();
+        }
+      }
+    }
+  }
+}
+""")
+
+    val source = JavaFileObjects.forSourceLines("test.HeroDetails", outputFile.readLines())
+    assertAbout(javaSources())
+      .that(listOf(source))
+      .compilesWithoutError()
+  }
 }


### PR DESCRIPTION
Add recursive interface generation support. Resolves #8 
Example of generated source
```
package test;

import java.lang.String;
import java.util.List;

public interface HeroDetails {
  Character hero();

  interface Character {
    String name();

    CharacterFriendsConnection friendsConnection();
  }

  interface CharacterFriendsConnection {
    int totalCount();

    List<CharacterFriendsConnectionFriendsEdge> edges();
  }

  interface CharacterFriendsConnectionFriendsEdge {
    CharacterFriendsConnectionFriendsEdgeCharacter node();
  }

  interface CharacterFriendsConnectionFriendsEdgeCharacter {
    String name();
  }
}
```