### PR TITLE
add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: android
+
+android:
+  components:
+    - build-tools-24.0.2
+    - android-24
+
+jdk:
+  - oraclejdk8
+
+script:
+  - ./gradlew clean check --info
+
+branches:
+  except:
+    - gh-pages
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.gradle


### PR DESCRIPTION
This would run the test suite on all modules. The client module would probably have some 
instrumentation tests so we might have to an emulator and run the `conncetedCheck` task for that module later on.

Tested on @felipecsl's branch.

Closes #6 

This should be good to go once an organization admin would enables Travis for this repo.
/cc @martijnwalraven 
