### PR TITLE
Handle nullability and nesting

### DIFF
--- a/apollo-compiler/build.gradle
+++ b/apollo-compiler/build.gradle
@@ -13,6 +13,8 @@ dependencies {
   compile dep.javaPoet
   compile dep.kotlinStdLib
   compile dep.moshi
+  compile dep.pluralizer
+  compile dep.jsr305
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/GraphqlCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/GraphqlCompiler.kt
@@ -2,24 +2,23 @@ package com.apollostack.compiler
 
 import com.apollostack.compiler.ir.QueryIntermediateRepresentation
 import com.squareup.javapoet.JavaFile
-import com.squareup.javapoet.TypeSpec
 import com.squareup.moshi.Moshi
 import java.io.File
 
 open class GraphqlCompiler {
   private val moshi = Moshi.Builder().build()
+  private val irAdapter = moshi.adapter(QueryIntermediateRepresentation::class.java)
 
   fun write(irFile: File) {
     val packageName = irFile.absolutePath.formatPackageName()
-    val irAdapter = moshi.adapter(QueryIntermediateRepresentation::class.java)
     val ir = irAdapter.fromJson(irFile.readText())
-    // TODO: Handle multiple or no operations
-    val operation = ir.operations.first()
-    val typeSpecBuilder = OperationTypeSpecBuilder(operation.operationName, operation.fields)
-    JavaFile
-      .builder(packageName, typeSpecBuilder.build())
-      .build()
-      .writeTo(OUTPUT_DIRECTORY.fold(File("build"), ::File))
+    ir.operations.forEach {
+      val typeSpecBuilder = OperationTypeSpecBuilder(it.operationName, it.fields)
+      JavaFile
+          .builder(packageName, typeSpecBuilder.build())
+          .build()
+          .writeTo(OUTPUT_DIRECTORY.fold(File("build"), ::File))
+    }
   }
 
   companion object {

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/OperationTypeSpecBuilder.kt
@@ -1,58 +1,26 @@
 package com.apollostack.compiler
 
 import com.apollostack.compiler.ir.Field
+import com.cesarferreira.pluralize.singularize
 import com.squareup.javapoet.TypeSpec
-import java.util.*
 import javax.lang.model.element.Modifier
 
 class OperationTypeSpecBuilder(
-  val operationName: String,
-  val fields: List<Field>
-) {
+    val operationName: String,
+    val fields: List<Field>) {
 
   fun build(): TypeSpec {
-    val typeSpecs = buildTypeSpecs(operationName, fields, "")
-    return typeSpecs
-      .single { it.name == operationName }
-      .toBuilder()
-      .addTypes(typeSpecs.filter { it.name != operationName })
-      .build()
+    return buildTypeSpecs(operationName, fields)
   }
 
-  private fun buildTypeSpecs(currentTypeName: String, fields: List<Field>, typeNamePrefix: String): List<TypeSpec> {
-    val fieldToTypeMap = HashMap<Field, String>()
-    val typeToFieldMap = HashMap<String, Field>()
-    val nonScalarFields = fields.filter { it.fields?.any() ?: false }
-    nonScalarFields.forEach {
-      val fieldType = "$typeNamePrefix${it.toTypeName()}"
-      val existingMapping = typeToFieldMap[fieldType]
-      if (existingMapping != null && it.fields != existingMapping.fields) {
-        // If we already saw this type and it has a different set of fields, it means
-        // we have the same type used multiple times with different fields. In this case,
-        // we'll use Field.toTypeName() to disambiguate the name since the type cannot be
-        // used more than once. We also need to use the explicit naming for the previously
-        // seen type, so we need to also remove it and re-add with the explicit naming.
-
-        val fieldNewType = "$typeNamePrefix${it.toTypeName(it.responseName)}"
-        typeToFieldMap.put(fieldNewType, it)
-        fieldToTypeMap.put(it, fieldNewType)
-
-        val existingFieldType = "$typeNamePrefix${it.toTypeName()}"
-        val existingFieldNewType = "$typeNamePrefix${existingMapping.toTypeName(existingMapping.responseName)}"
-        typeToFieldMap.put(existingFieldNewType, existingMapping)
-        typeToFieldMap.remove(existingFieldType)
-        fieldToTypeMap.put(existingMapping, existingFieldNewType)
-      } else {
-        typeToFieldMap.put(fieldType, it)
-        fieldToTypeMap.put(it, fieldType)
-      }
-    }
-
-    val typeSpec = TypeSpec.interfaceBuilder(currentTypeName)
-      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-      .addMethods(fields.map { it.toMethodSpec(fieldToTypeMap[it]) })
-      .build()
-
-    return listOf(typeSpec) + typeToFieldMap.flatMap { buildTypeSpecs(it.key, it.value.fields!!, it.key) }
+  private fun buildTypeSpecs(currentTypeName: String, fields: List<Field>): TypeSpec {
+    val innerTypes = fields
+        .filter(Field::isNonScalar)
+        .map { buildTypeSpecs(it.responseName.capitalize().singularize(), it.fields!!) }
+    return TypeSpec.interfaceBuilder(currentTypeName)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addMethods(fields.map(Field::toMethodSpec))
+        .addTypes(innerTypes)
+        .build()
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/Util.kt
@@ -1,0 +1,3 @@
+package com.apollostack.compiler
+
+fun String.normalizeTypeName() = removeSuffix("!").removeSurrounding("[", "]").removeSuffix("!")

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
@@ -21,7 +21,6 @@ data class Field(
       GraphQlType.resolveByName(responseType).toJavaTypeName()
 
   private fun methodResponsType(): String {
-    // TODO: Do we also need to handle nested lists?
     if (isNonScalar()) {
       // For non scalar fields, we use the responseName as the method return type.
       // However, we need to also encode any extra information from the `type` field

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
@@ -1,31 +1,46 @@
 package com.apollostack.compiler.ir
 
+import com.cesarferreira.pluralize.singularize
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.TypeName
 import javax.lang.model.element.Modifier
 
 data class Field(
-  val responseName: String,
-  val fieldName: String,
-  val type: String,
-  val fields: List<Field>?
-) {
-
-  fun toTypeName(prefix: String? = null) = "${prefix?.capitalize() ?: ""}${type.normalizeTypeName()}"
-
-  fun toMethodSpec(returnTypeOverride: String? = null): MethodSpec {
-    val typeName = returnTypeOverride
-      ?.let { if (type.startsWith('[') && type.endsWith(']')) "[${it.normalizeTypeName()}]" else it.normalizeTypeName() }
-      ?.toTypeName()
-      ?: type.toTypeName()
-
+    val responseName: String,
+    val fieldName: String,
+    val type: String,
+    val fields: List<Field>?) {
+  fun toMethodSpec(): MethodSpec {
     return MethodSpec.methodBuilder(responseName)
-      .returns(typeName)
-      .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-      .build()
+        .returns(toTypeName(methodResponsType()))
+        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+        .build()
   }
 
-  private fun String.toTypeName(): TypeName = GraphQlType.resolveByName(this).toJavaTypeName()
+  private fun toTypeName(responseType: String): TypeName =
+      GraphQlType.resolveByName(responseType).toJavaTypeName()
 
-  private fun String.normalizeTypeName() = removeSuffix("!").removeSurrounding(prefix = "[", suffix = "]").removeSuffix("!")
+  private fun methodResponsType(): String {
+    // TODO: Do we also need to handle nested lists?
+    if (isNonScalar()) {
+      // For non scalar fields, we use the responseName as the method return type.
+      // However, we need to also encode any extra information from the `type` field
+      // eg, [lists], nonNulls!, [[nestedLists]], [nonNullLists]!, etc
+      val normalizedName = responseName.capitalize().singularize()
+      if (type.startsWith("[")) {
+        // array type
+        return if (type.endsWith("!")) "[$normalizedName]!" else "[$normalizedName]"
+      } else if (type.endsWith("!")) {
+        // non-null type
+        return "$normalizedName!"
+      } else {
+        // nullable type
+        return normalizedName
+      }
+    } else {
+      return type
+    }
+  }
+
+  fun isNonScalar() = fields?.any() ?: false
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
@@ -1,11 +1,13 @@
 package com.apollostack.compiler.ir
 
+import com.apollostack.compiler.normalizeTypeName
+import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
+import javax.annotation.Nullable
 
 sealed class GraphQlType(val nullable: Boolean) {
-
   class GraphQlString(nullable: Boolean) : GraphQlType(nullable)
 
   class GraphQlId(nullable: Boolean) : GraphQlType(nullable)
@@ -20,21 +22,17 @@ sealed class GraphQlType(val nullable: Boolean) {
 
   class GraphQlUnknown(nullable: Boolean, val typeName: String) : GraphQlType(nullable)
 
-  fun toJavaTypeName(): TypeName {
-    return when (this) {
-      is GraphQlString -> ClassName.get(String::class.java)
-      is GraphQlId -> if (nullable) ClassName.get(java.lang.Long::class.java) else ClassName.LONG
-      is GraphQlInt -> if (nullable) ClassName.get(java.lang.Integer::class.java) else TypeName.INT
-      is GraphQLFloat -> if (nullable) ClassName.get(java.lang.Float::class.java) else TypeName.FLOAT
-      is GraphQLBoolean -> if (nullable) ClassName.get(java.lang.Boolean::class.java) else TypeName.BOOLEAN
-      is GraphQLList -> ParameterizedTypeName.get(ClassName.get(List::class.java), listType.toJavaTypeName())
-      is GraphQlUnknown -> ClassName.get("", typeName)
-    }
-  }
+  fun toJavaTypeName() = graphQlTypeToJavaTypeName(this, !nullable, nullable)
 
   companion object {
-
-    private fun String.normalizeTypeName() = removeSuffix("!").removeSurrounding(prefix = "[", suffix = "]").removeSuffix("!")
+    private val NULLABLE_ANNOTATION = AnnotationSpec.builder(Nullable::class.java).build()
+    private val LIST_TYPE = ClassName.get(List::class.java)
+    private val GRAPHQLTYPE_TO_JAVA_TIME = mapOf(
+        GraphQlString::class.java to ClassName.get(String::class.java),
+        GraphQlId::class.java to TypeName.LONG,
+        GraphQlInt::class.java to TypeName.INT,
+        GraphQLFloat::class.java to TypeName.FLOAT,
+        GraphQLBoolean::class.java to TypeName.BOOLEAN)
 
     fun resolveByName(typeName: String): GraphQlType = when {
       typeName.startsWith("String") -> GraphQlString(!typeName.endsWith("!"))
@@ -42,8 +40,29 @@ sealed class GraphQlType(val nullable: Boolean) {
       typeName.startsWith("Int") -> GraphQlInt(!typeName.endsWith("!"))
       typeName.startsWith("Boolean") -> GraphQLBoolean(!typeName.endsWith("!"))
       typeName.startsWith("Float") -> GraphQLFloat(!typeName.endsWith("!"))
-      typeName.removeSuffix("!").let { it.startsWith('[') && it.endsWith(']') } -> GraphQLList(!typeName.endsWith("!"), resolveByName(typeName.normalizeTypeName()))
+      typeName.removeSuffix("!").let { it.startsWith('[') && it.endsWith(']') } -> GraphQLList(
+          !typeName.endsWith("!"), resolveByName(typeName.normalizeTypeName()))
       else -> GraphQlUnknown(!typeName.endsWith("!"), typeName.normalizeTypeName())
+    }
+
+    fun graphQlTypeToJavaTypeName(
+        type: GraphQlType,
+        primitive: Boolean,
+        nullable: Boolean): TypeName {
+      val typeName = when (type) {
+        is GraphQLList -> ParameterizedTypeName.get(LIST_TYPE,
+            graphQlTypeToJavaTypeName(type.listType, false, false))
+        is GraphQlUnknown -> ClassName.get("", type.typeName)
+        else ->
+          GRAPHQLTYPE_TO_JAVA_TIME[type.javaClass]!!.let {
+            if (primitive) it else it.box()
+          }
+      }
+      return if (nullable) {
+        typeName.annotated(NULLABLE_ANNOTATION)
+      } else {
+        typeName
+      }
     }
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
@@ -27,7 +27,7 @@ sealed class GraphQlType(val nullable: Boolean) {
   companion object {
     private val NULLABLE_ANNOTATION = AnnotationSpec.builder(Nullable::class.java).build()
     private val LIST_TYPE = ClassName.get(List::class.java)
-    private val GRAPHQLTYPE_TO_JAVA_TIME = mapOf(
+    private val GRAPHQLTYPE_TO_JAVA_TIPE = mapOf(
         GraphQlString::class.java to ClassName.get(String::class.java),
         GraphQlId::class.java to TypeName.LONG,
         GraphQlInt::class.java to TypeName.INT,
@@ -54,7 +54,7 @@ sealed class GraphQlType(val nullable: Boolean) {
             graphQlTypeToJavaTypeName(type.listType, false, false))
         is GraphQlUnknown -> ClassName.get("", type.typeName)
         else ->
-          GRAPHQLTYPE_TO_JAVA_TIME[type.javaClass]!!.let {
+          GRAPHQLTYPE_TO_JAVA_TIPE[type.javaClass]!!.let {
             if (primitive) it else it.box()
           }
       }

--- a/apollo-compiler/src/test/graphql/com/example/HeroDetailsExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/HeroDetailsExpected.java
@@ -3,27 +3,28 @@ package com.example;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public interface HeroDetails {
-  Character hero();
+  @Nullable Hero hero();
 
-  interface Character {
+  interface Hero {
     String name();
 
-    CharacterFriendsConnection friendsConnection();
-  }
+    FriendsConnection friendsConnection();
 
-  interface CharacterFriendsConnection {
-    Integer totalCount();
+    interface FriendsConnection {
+      @Nullable Integer totalCount();
 
-    List<CharacterFriendsConnectionFriendsEdge> edges();
-  }
+      @Nullable List<Edge> edges();
 
-  interface CharacterFriendsConnectionFriendsEdge {
-    CharacterFriendsConnectionFriendsEdgeCharacter node();
-  }
+      interface Edge {
+        @Nullable Node node();
 
-  interface CharacterFriendsConnectionFriendsEdgeCharacter {
-    String name();
+        interface Node {
+          String name();
+        }
+      }
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/HeroNameExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/HeroNameExpected.java
@@ -1,11 +1,12 @@
 package com.example;
 
 import java.lang.String;
+import javax.annotation.Nullable;
 
 public interface HeroName {
-  Character hero();
+  @Nullable Hero hero();
 
-  interface Character {
+  interface Hero {
     String name();
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/ScalarTypesExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/ScalarTypesExpected.java
@@ -6,33 +6,34 @@ import java.lang.Integer;
 import java.lang.Long;
 import java.lang.String;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public interface ScalarTypes {
-  String graphQlString();
+  @Nullable String graphQlString();
 
-  Long graphQlIdNullable();
+  @Nullable Long graphQlIdNullable();
 
   long graphQlIdNonNullable();
 
-  Integer graphQlIntNullable();
+  @Nullable Integer graphQlIntNullable();
 
   int graphQlIntNonNullable();
 
-  Float graphQlFloatNullable();
+  @Nullable Float graphQlFloatNullable();
 
   float graphQlFloatNonNullable();
 
-  Boolean graphQlBooleanNullable();
+  @Nullable Boolean graphQlBooleanNullable();
 
   boolean graphQlBooleanNonNullable();
 
-  List<Integer> graphQlListOfInt();
+  @Nullable List<Integer> graphQlListOfInt();
 
-  List<SomeObject> graphQlListOfObjects();
+  @Nullable List<GraphQlListOfObject> graphQlListOfObjects();
 
-  List<List<Integer>> graphQlNestedList();
+  @Nullable List<List<Integer>> graphQlNestedList();
 
-  interface SomeObject {
+  interface GraphQlListOfObject {
     int someField();
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/TwoHeroesExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/TwoHeroesExpected.java
@@ -1,13 +1,18 @@
 package com.example;
 
 import java.lang.String;
+import javax.annotation.Nullable;
 
 public interface TwoHeroes {
-  Character r2();
+  @Nullable R2 r2();
 
-  Character luke();
+  @Nullable Luke luke();
 
-  interface Character {
+  interface R2 {
+    String name();
+  }
+
+  interface Luke {
     String name();
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/TwoHeroesUniqueExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/TwoHeroesUniqueExpected.java
@@ -1,19 +1,20 @@
 package com.example;
 
 import java.lang.String;
+import javax.annotation.Nullable;
 
 public interface TwoHeroesUnique {
-  R2Character r2();
+  @Nullable R2 r2();
 
-  LukeCharacter luke();
+  @Nullable Luke luke();
 
-  interface LukeCharacter {
-    long id();
-
+  interface R2 {
     String name();
   }
 
-  interface R2Character {
+  interface Luke {
+    long id();
+
     String name();
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -18,10 +18,10 @@ class GraphqlCompilerTest {
     compiler.write(irFile)
     assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
 
-    val source = JavaFileObjects.forSourceLines("com.apollostack.compiler.query.HeroName", actualFile.readLines())
+    val source = JavaFileObjects.forSourceLines("com.example.HeroName", actualFile.readLines())
     assertAbout(javaSources())
-      .that(listOf(source))
-      .compilesWithoutError()
+        .that(listOf(source))
+        .compilesWithoutError()
   }
 
   @Test fun twoHeroes() {
@@ -32,10 +32,10 @@ class GraphqlCompilerTest {
     compiler.write(irFile)
     assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
 
-    val source = JavaFileObjects.forSourceLines("com.apollostack.compiler.query.TwoHeroes", actualFile.readLines())
+    val source = JavaFileObjects.forSourceLines("com.example.TwoHeroes", actualFile.readLines())
     assertAbout(javaSources())
-      .that(listOf(source))
-      .compilesWithoutError()
+        .that(listOf(source))
+        .compilesWithoutError()
   }
 
   @Test fun heroDetails() {
@@ -46,10 +46,10 @@ class GraphqlCompilerTest {
     compiler.write(irFile)
     assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
 
-    val source = JavaFileObjects.forSourceLines("com.apollostack.compiler.query.HeroDetails", actualFile.readLines())
+    val source = JavaFileObjects.forSourceLines("com.example.HeroDetails", actualFile.readLines())
     assertAbout(javaSources())
-      .that(listOf(source))
-      .compilesWithoutError()
+        .that(listOf(source))
+        .compilesWithoutError()
   }
 
   @Test fun twoHeroesUnique() {
@@ -60,10 +60,11 @@ class GraphqlCompilerTest {
     compiler.write(irFile)
     assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
 
-    val source = JavaFileObjects.forSourceLines("com.apollostack.compiler.query.TwoHeroesUnique", actualFile.readLines())
+    val source = JavaFileObjects.forSourceLines("com.example.TwoHeroesUnique",
+        actualFile.readLines())
     assertAbout(javaSources())
-      .that(listOf(source))
-      .compilesWithoutError()
+        .that(listOf(source))
+        .compilesWithoutError()
   }
 
   @Test fun graphQlScalarTypes() {
@@ -74,9 +75,9 @@ class GraphqlCompilerTest {
     compiler.write(irFile)
     assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
 
-    val source = JavaFileObjects.forSourceLines("com.apollostack.compiler.query.ScalarTypes", actualFile.readLines())
+    val source = JavaFileObjects.forSourceLines("com.example.ScalarTypes", actualFile.readLines())
     assertAbout(javaSources())
-      .that(listOf(source))
-      .compilesWithoutError()
+        .that(listOf(source))
+        .compilesWithoutError()
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ ext {
       compiletesting: 'com.google.testing.compile:compile-testing:0.10',
       javaPoet: 'com.squareup:javapoet:1.8.0',
       moshi: 'com.squareup.moshi:moshi:1.3.1',
+      jsr305: 'com.google.code.findbugs:jsr305:3.0.1',
+      pluralizer: 'com.github.cesarferreira:kotlin-pluralizer:0.2.7',
       kotlinStdLib: "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
       kotlinReflect: "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
       kotlinGradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
@@ -34,6 +36,7 @@ subprojects {
   repositories {
     mavenCentral()
     jcenter()
+    maven { url "https://jitpack.io" }
   }
 
   group = GROUP


### PR DESCRIPTION
this PR was supposed to handle just the Nullability part, but turned out
to be much bigger since once I started to implement that, I started
bumping into roadblocks with the current implementation that wouldn't
let me properly propragate the nullability information without
refactoring a lot of code.
It ended up being much easier to also make the change to generate
nested types with the correct names based on the responseName field.
The code turned out to be **at lot** simpler and much more similar to
the Swift counterparts. This still doesnt handle deduping of duplicate
types but that shouldnt be too hard to implement now. We just need to
decide on how to actualy do it (maybe add a suffix to the interface
name? Maybe a number, or a letter, or a symbol?) I'm open to ideas here.

Fixes #10 and #17 