### PR TITLE
check whole irFile absolute path for package strings

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/GraphqlCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/GraphqlCompiler.kt
@@ -34,12 +34,12 @@ open class GraphqlCompiler {
 
   private fun String.formatPackageName(): String {
     val parts = split(File.separatorChar)
-    val srcFolderIndex = parts.indexOfFirst { it == "src" }
-    val graphqlFolderIndex = parts.indexOfFirst { it == "graphql" }
-    if (graphqlFolderIndex - srcFolderIndex != 2) {
-      throw IllegalArgumentException("Files must be organized like src/main/graphql/...")
-    }
 
-    return parts.subList(graphqlFolderIndex + 1, parts.size).dropLast(1).joinToString(".")
+    for (i in 2..parts.size) {
+      if (parts[i - 2] == "src" && parts[i] == "graphql") {
+        return parts.subList(i + 1, parts.size).dropLast(1).joinToString(".")
+      }
+    }
+    throw IllegalArgumentException("Files must be organized like src/main/graphql/...")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
@@ -12,7 +12,7 @@ data class Field(
     val fields: List<Field>?) {
   fun toMethodSpec(): MethodSpec {
     return MethodSpec.methodBuilder(responseName)
-        .returns(toTypeName(methodResponsType()))
+        .returns(toTypeName(methodResponseType()))
         .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
         .build()
   }
@@ -20,7 +20,7 @@ data class Field(
   private fun toTypeName(responseType: String): TypeName =
       GraphQlType.resolveByName(responseType).toJavaTypeName()
 
-  private fun methodResponsType(): String {
+  private fun methodResponseType(): String {
     if (isNonScalar()) {
       // For non scalar fields, we use the responseName as the method return type.
       // However, we need to also encode any extra information from the `type` field

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -10,6 +10,16 @@ import java.io.File
 class GraphqlCompilerTest {
   private val compiler = GraphqlCompiler()
 
+  @Test fun shouldThrowExceptionForInvalidIrPath() {
+    val irFile = File("src/test/dummyfolder/graphql/com/example/HeroName.json")
+    try {
+      compiler.write(irFile)
+    }
+    catch (ex: IllegalArgumentException) {
+      assertThat(ex.message.equals("Files must be organized like src/main/graphql/..."))
+    }
+  }
+
   @Test fun heroName() {
     val irFile = File("src/test/graphql/com/example/HeroName.json")
     val actualFile = File("build/generated/source/apollo/com/example/HeroName.java")

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollostack/android/gradle/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollostack/android/gradle/ApolloPlugin.kt
@@ -30,7 +30,7 @@ class ApolloPlugin : Plugin<Project> {
       val task = project.tasks.create(taskName, ApolloTask::class.java)
       task.group = "apollo"
       task.buildDirectory = project.buildDir
-      task.description = "Generate Android interfaces for working with ${it.name} database tables"
+      task.description = "Generate Android interfaces for working with ${it.name} GraphQL queries"
       task.source("src")
       task.include("**${File.separatorChar}*.${GraphqlCompiler.FILE_EXTENSION}")
 


### PR DESCRIPTION
Instead of just searching for the first occurrence of 'src' and 'graphql' in the irFile absolute path, attempt to look for a distance 2 separation.

This guards against the issue for someone with `/Users/name/Desktop/src/github/apollo-client/src/main/graphql` for instance.

@felipecsl @sav007 