### PR TITLE
Support field directives

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Field.kt
@@ -11,6 +11,7 @@ data class Field(
     val responseName: String,
     val fieldName: String,
     val type: String,
+    val isConditional: Boolean = false,
     val fields: List<Field>?,
     val fragmentSpreads: List<String>?
 ) : CodeGenerator {
@@ -28,7 +29,7 @@ data class Field(
       allFragments.filter { fragmentSpreads?.contains(it.fragmentName) ?: false }
 
   private fun toTypeName(responseType: String): TypeName =
-      GraphQlType.resolveByName(responseType).toJavaTypeName()
+      GraphQlType.resolveByName(responseType, isOptional()).toJavaTypeName()
 
   fun normalizedName() = responseName.capitalize().singularize()
 
@@ -56,4 +57,6 @@ data class Field(
   fun isNonScalar() = fields?.any() ?: false
 
   fun hasFragments() = fragmentSpreads?.any() ?: false
+
+  fun isOptional(): Boolean = isConditional || !methodResponseType().endsWith("!")
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
@@ -7,22 +7,22 @@ import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import javax.annotation.Nullable
 
-sealed class GraphQlType(val nullable: Boolean) {
-  class GraphQlString(nullable: Boolean) : GraphQlType(nullable)
+sealed class GraphQlType(val isOptional: Boolean) {
+  class GraphQlString(isOptional: Boolean) : GraphQlType(isOptional)
 
-  class GraphQlId(nullable: Boolean) : GraphQlType(nullable)
+  class GraphQlId(isOptional: Boolean) : GraphQlType(isOptional)
 
-  class GraphQlInt(nullable: Boolean) : GraphQlType(nullable)
+  class GraphQlInt(isOptional: Boolean) : GraphQlType(isOptional)
 
-  class GraphQLFloat(nullable: Boolean) : GraphQlType(nullable)
+  class GraphQLFloat(isOptional: Boolean) : GraphQlType(isOptional)
 
-  class GraphQLBoolean(nullable: Boolean) : GraphQlType(nullable)
+  class GraphQLBoolean(isOptional: Boolean) : GraphQlType(isOptional)
 
-  class GraphQLList(nullable: Boolean, val listType: GraphQlType) : GraphQlType(nullable)
+  class GraphQLList(isOptional: Boolean, val listType: GraphQlType) : GraphQlType(isOptional)
 
-  class GraphQlUnknown(nullable: Boolean, val typeName: String) : GraphQlType(nullable)
+  class GraphQlUnknown(isOptional: Boolean, val typeName: String) : GraphQlType(isOptional)
 
-  fun toJavaTypeName() = graphQlTypeToJavaTypeName(this, !nullable, nullable)
+  fun toJavaTypeName() = graphQlTypeToJavaTypeName(this, !isOptional, isOptional)
 
   companion object {
     private val NULLABLE_ANNOTATION = AnnotationSpec.builder(Nullable::class.java).build()
@@ -34,21 +34,21 @@ sealed class GraphQlType(val nullable: Boolean) {
         GraphQLFloat::class.java to TypeName.FLOAT,
         GraphQLBoolean::class.java to TypeName.BOOLEAN)
 
-    fun resolveByName(typeName: String): GraphQlType = when {
-      typeName.startsWith("String") -> GraphQlString(!typeName.endsWith("!"))
-      typeName.startsWith("ID") -> GraphQlId(!typeName.endsWith("!"))
-      typeName.startsWith("Int") -> GraphQlInt(!typeName.endsWith("!"))
-      typeName.startsWith("Boolean") -> GraphQLBoolean(!typeName.endsWith("!"))
-      typeName.startsWith("Float") -> GraphQLFloat(!typeName.endsWith("!"))
+    fun resolveByName(typeName: String, isOptional: Boolean): GraphQlType = when {
+      typeName.startsWith("String") -> GraphQlString(isOptional)
+      typeName.startsWith("ID") -> GraphQlId(isOptional)
+      typeName.startsWith("Int") -> GraphQlInt(isOptional)
+      typeName.startsWith("Boolean") -> GraphQLBoolean(isOptional)
+      typeName.startsWith("Float") -> GraphQLFloat(isOptional)
       typeName.removeSuffix("!").let { it.startsWith('[') && it.endsWith(']') } -> GraphQLList(
-          !typeName.endsWith("!"), resolveByName(typeName.normalizeTypeName()))
-      else -> GraphQlUnknown(!typeName.endsWith("!"), typeName.normalizeTypeName())
+              isOptional, resolveByName(typeName.normalizeTypeName(), isOptional))
+      else -> GraphQlUnknown(isOptional, typeName.normalizeTypeName())
     }
 
     fun graphQlTypeToJavaTypeName(
         type: GraphQlType,
         primitive: Boolean,
-        nullable: Boolean): TypeName {
+        isOptional: Boolean): TypeName {
       val typeName = when (type) {
         is GraphQLList -> ParameterizedTypeName.get(LIST_TYPE,
             graphQlTypeToJavaTypeName(type.listType, false, false))
@@ -58,7 +58,7 @@ sealed class GraphQlType(val nullable: Boolean) {
             if (primitive) it else it.box()
           }
       }
-      return if (nullable) {
+      return if (isOptional) {
         typeName.annotated(NULLABLE_ANNOTATION)
       } else {
         typeName

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/GraphQlType.kt
@@ -27,7 +27,7 @@ sealed class GraphQlType(val nullable: Boolean) {
   companion object {
     private val NULLABLE_ANNOTATION = AnnotationSpec.builder(Nullable::class.java).build()
     private val LIST_TYPE = ClassName.get(List::class.java)
-    private val GRAPHQLTYPE_TO_JAVA_TIPE = mapOf(
+    private val GRAPHQLTYPE_TO_JAVA_TYPE = mapOf(
         GraphQlString::class.java to ClassName.get(String::class.java),
         GraphQlId::class.java to TypeName.LONG,
         GraphQlInt::class.java to TypeName.INT,
@@ -54,7 +54,7 @@ sealed class GraphQlType(val nullable: Boolean) {
             graphQlTypeToJavaTypeName(type.listType, false, false))
         is GraphQlUnknown -> ClassName.get("", type.typeName)
         else ->
-          GRAPHQLTYPE_TO_JAVA_TIPE[type.javaClass]!!.let {
+          GRAPHQLTYPE_TO_JAVA_TYPE[type.javaClass]!!.let {
             if (primitive) it else it.box()
           }
       }

--- a/apollo-compiler/src/test/graphql/com/example/directives/HeroNameDirective.json
+++ b/apollo-compiler/src/test/graphql/com/example/directives/HeroNameDirective.json
@@ -1,0 +1,30 @@
+{
+  "operations": [
+    {
+      "operationName": "HeroNameDirective",
+      "operationType": "query",
+      "variables": [],
+      "source": "query HeroNameDirective {\n  hero {\n    __typename\n    name @include(if: false)\n  }\n}",
+      "fields": [
+        {
+          "responseName": "hero",
+          "fieldName": "hero",
+          "type": "Character",
+          "fields": [
+            {
+              "responseName": "name",
+              "fieldName": "name",
+              "type": "String!",
+              "isConditional": true
+            }
+          ],
+          "fragmentSpreads": [],
+          "inlineFragments": []
+        }
+      ],
+      "fragmentsReferenced": []
+    }
+  ],
+  "fragments": [],
+  "typesUsed": []
+}

--- a/apollo-compiler/src/test/graphql/com/example/directives/HeroNameDirectiveExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/HeroNameDirectiveExpected.java
@@ -1,0 +1,12 @@
+package com.example.directives;
+
+import java.lang.String;
+import javax.annotation.Nullable;
+
+public interface HeroNameDirective {
+  @Nullable Hero hero();
+
+  interface Hero {
+    @Nullable String name();
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/HeroAppearsIn.json
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/HeroAppearsIn.json
@@ -4,7 +4,7 @@
       "operationName": "HeroAppearsIn",
       "operationType": "query",
       "variables": [],
-      "source": "query HeroDetails {\n  hero {\n    __typename\n    name\n    appearsIn\n  }\n}",
+      "source": "query HeroAppearsIn {\n  hero {\n    __typename\n    name\n    appearsIn\n  }\n}",
       "fields": [
         {
           "responseName": "hero",

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -20,10 +20,10 @@ class GraphqlCompilerTest {
   }
 
   @Test fun heroName() {
-    val actual = File("build/generated/source/apollo/com/example/hero_name/HeroName.java")
-    val expected = File("src/test/graphql/com/example/hero_name/HeroNameExpected.java")
+    val actual = actualFileFor("hero_name", "HeroName")
+    val expected = expectedFileFor("hero_name", "HeroName")
 
-    compiler.write(File("src/test/graphql/com/example/hero_name/HeroName.json"))
+    compiler.write(irFileFor("hero_name", "HeroName"))
     assertThat(actual.readText()).isEqualTo(expected.readText())
 
     assertAbout(javaSources())
@@ -32,10 +32,10 @@ class GraphqlCompilerTest {
   }
 
   @Test fun twoHeroes() {
-    val actual = File("build/generated/source/apollo/com/example/two_heroes/TwoHeroes.java")
-    val expected = File("src/test/graphql/com/example/two_heroes/TwoHeroesExpected.java")
+    val actual = actualFileFor("two_heroes", "TwoHeroes")
+    val expected = expectedFileFor("two_heroes", "TwoHeroes")
 
-    compiler.write(File("src/test/graphql/com/example/two_heroes/TwoHeroes.json"))
+    compiler.write(irFileFor("two_heroes", "TwoHeroes"))
     assertThat(actual.readText()).isEqualTo(expected.readText())
 
     assertAbout(javaSources())
@@ -44,10 +44,10 @@ class GraphqlCompilerTest {
   }
 
   @Test fun heroDetails() {
-    val actual = File("build/generated/source/apollo/com/example/hero_details/HeroDetails.java")
-    val expected = File("src/test/graphql/com/example/hero_details/HeroDetailsExpected.java")
+    val actual = actualFileFor("hero_details", "HeroDetails")
+    val expected = expectedFileFor("hero_details", "HeroDetails")
 
-    compiler.write(File("src/test/graphql/com/example/hero_details/HeroDetails.json"))
+    compiler.write(irFileFor("hero_details", "HeroDetails"))
     assertThat(actual.readText()).isEqualTo(expected.readText())
 
     assertAbout(javaSources())
@@ -56,12 +56,10 @@ class GraphqlCompilerTest {
   }
 
   @Test fun twoHeroesUnique() {
-    val actual = File(
-        "build/generated/source/apollo/com/example/two_heroes_unique/TwoHeroesUnique.java")
-    val expected = File(
-        "src/test/graphql/com/example/two_heroes_unique/TwoHeroesUniqueExpected.java")
+    val actual = actualFileFor("two_heroes_unique", "TwoHeroesUnique")
+    val expected = expectedFileFor("two_heroes_unique", "TwoHeroesUnique")
 
-    compiler.write(File("src/test/graphql/com/example/two_heroes_unique/TwoHeroesUnique.json"))
+    compiler.write(irFileFor("two_heroes_unique", "TwoHeroesUnique"))
     assertThat(actual.readText()).isEqualTo(expected.readText())
 
     assertAbout(javaSources())
@@ -70,10 +68,10 @@ class GraphqlCompilerTest {
   }
 
   @Test fun scalarTypes() {
-    val actual = File("build/generated/source/apollo/com/example/scalar_types/ScalarTypes.java")
-    val expected = File("src/test/graphql/com/example/scalar_types/ScalarTypesExpected.java")
+    val actual = actualFileFor("scalar_types", "ScalarTypes")
+    val expected = expectedFileFor("scalar_types", "ScalarTypes")
 
-    compiler.write(File("src/test/graphql/com/example/scalar_types/ScalarTypes.json"))
+    compiler.write(irFileFor("scalar_types", "ScalarTypes"))
     assertThat(actual.readText()).isEqualTo(expected.readText())
 
     val source = JavaFileObjects.forSourceLines("test.ScalarTypes", actual.readLines())
@@ -83,12 +81,12 @@ class GraphqlCompilerTest {
   }
 
   @Test fun enumType() {
-    val actual = File("build/generated/source/apollo/com/example/enum_type/HeroAppearsIn.java")
-    val expected = File("src/test/graphql/com/example/enum_type/HeroAppearsInExpected.java")
-    val episodeEnumActual = File("build/generated/source/apollo/com/example/enum_type/Episode.java")
-    val episodeEnumExpected = File("src/test/graphql/com/example/enum_type/EpisodeExpected.java")
+    val actual = actualFileFor("enum_type", "HeroAppearsIn")
+    val expected = expectedFileFor("enum_type", "HeroAppearsIn")
+    val episodeEnumActual = actualFileFor("enum_type", "Episode")
+    val episodeEnumExpected = expectedFileFor("enum_type", "Episode")
 
-    compiler.write(File("src/test/graphql/com/example/enum_type/HeroAppearsIn.json"))
+    compiler.write(irFileFor("enum_type", "HeroAppearsIn"))
 
     assertThat(actual.readText()).isEqualTo(expected.readText())
     assertThat(episodeEnumActual.readText()).isEqualTo(episodeEnumExpected.readText())
@@ -102,15 +100,12 @@ class GraphqlCompilerTest {
   }
 
   @Test fun simpleFragment() {
-    val actual = File(
-        "build/generated/source/apollo/com/example/simple_fragment/SimpleFragment.java")
-    val expected = File("src/test/graphql/com/example/simple_fragment/SimpleFragmentExpected.java")
-    val fragmentActual = File(
-        "build/generated/source/apollo/com/example/simple_fragment/HeroDetails.java")
-    val fragmentExpected = File(
-        "src/test/graphql/com/example/simple_fragment/HeroDetailsExpected.java")
+    val actual = actualFileFor("simple_fragment", "SimpleFragment")
+    val expected = expectedFileFor("simple_fragment", "SimpleFragment")
+    val fragmentActual = actualFileFor("simple_fragment", "HeroDetails")
+    val fragmentExpected = expectedFileFor("simple_fragment", "HeroDetails")
 
-    compiler.write(File("src/test/graphql/com/example/simple_fragment/SimpleFragment.json"))
+    compiler.write(irFileFor("simple_fragment", "SimpleFragment"))
 
     assertThat(actual.readText()).isEqualTo(expected.readText())
     assertThat(fragmentActual.readText()).isEqualTo(fragmentExpected.readText())
@@ -124,17 +119,12 @@ class GraphqlCompilerTest {
   }
 
   @Test fun fragmentFriendsConnection() {
-    val actual = File("build/generated/source/apollo/com/example/fragment_friends_connection/" +
-        "FragmentFriendsConnection.java")
-    val expected = File("src/test/graphql/com/example/fragment_friends_connection/" +
-        "FragmentFriendsConnectionExpected.java")
-    val fragmentActual = File(
-        "build/generated/source/apollo/com/example/fragment_friends_connection/HeroDetails.java")
-    val fragmentExpected = File(
-        "src/test/graphql/com/example/fragment_friends_connection/HeroDetailsExpected.java")
+    val actual = actualFileFor("fragment_friends_connection", "FragmentFriendsConnection")
+    val expected = expectedFileFor("fragment_friends_connection", "FragmentFriendsConnection")
+    val fragmentActual = actualFileFor("fragment_friends_connection", "HeroDetails")
+    val fragmentExpected = expectedFileFor("fragment_friends_connection", "HeroDetails")
 
-    compiler.write(File(
-        "src/test/graphql/com/example/fragment_friends_connection/FragmentFriendsConnection.json"))
+    compiler.write(irFileFor("fragment_friends_connection", "FragmentFriendsConnection"))
 
     assertThat(actual.readText()).isEqualTo(expected.readText())
     assertThat(fragmentActual.readText()).isEqualTo(fragmentExpected.readText())

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/GraphqlCompilerTest.kt
@@ -137,4 +137,12 @@ class GraphqlCompilerTest {
         .that(listOf(source, fragment))
         .compilesWithoutError()
   }
+
+  @Test fun fieldDirectives() {
+    val actualFile = actualFileFor("directives", "HeroNameDirective")
+    val expectedFile = expectedFileFor("directives", "HeroNameDirective")
+
+    compiler.write(irFileFor("directives", "HeroNameDirective"))
+    assertThat(actualFile.readText()).isEqualTo(expectedFile.readText())
+  }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollostack/compiler/Utils.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollostack/compiler/Utils.kt
@@ -1,0 +1,13 @@
+package com.apollostack.compiler
+
+import java.io.File
+
+fun irFileFor(pkg: String, queryFileName: String) =
+        File("src/test/graphql/com/example/${pkg}/${queryFileName}.json")
+
+fun actualFileFor(pkg: String, queryFileName: String) =
+        File("build/generated/source/apollo/com/example/${pkg}/${queryFileName}.java")
+
+fun expectedFileFor(pkg: String, queryFileName: String) =
+        File("src/test/graphql/com/example/${pkg}/${queryFileName}Expected.java")
+


### PR DESCRIPTION
The first commit just refactors some of the File creation methods in the test files. 

For the second commit, the approach was as followsL

The generated IR provides an optional `isConditional` field  if the 'skip' or 'include' directives exist. 
I pushed the nullable check back to the Fields class and combined that with isConditional to yield `isOptional`.

I feel that it makes more sense for the non-null check to be part of the field class but I'm open to discussions/suggestions on that.
