### PR TITLE
Update query code generation

### DIFF
--- a/apollo-api/src/main/java/com/apollostack/api/Query.java
+++ b/apollo-api/src/main/java/com/apollostack/api/Query.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /** TODO */
 public interface Query<V extends Query.Variables> {
   /** TODO */
-  String operationDefinition();
+  String queryDocument();
 
   /** TODO */
   V variables();

--- a/apollo-api/src/main/java/com/apollostack/api/Query.java
+++ b/apollo-api/src/main/java/com/apollostack/api/Query.java
@@ -1,17 +1,34 @@
 package com.apollostack.api;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 /** TODO */
-public interface Query {
+public interface Query<V extends Query.Variables> {
   /** TODO */
   String operationDefinition();
+
   /** TODO */
-  List<String> fragmentDefinitions();
-  /** TODO */
-  Map<String, Object> variableDefinitions();
+  V variables();
+
   /** TODO */
   interface Data {
   }
+
+  /** TODO */
+  abstract class Variables {
+    protected final Map<String, Object> data;
+
+    protected Variables(Map<String, Object> data) {
+      this.data = Collections.unmodifiableMap(data);
+    }
+
+    /** TODO */
+    public Map<String, Object> toMap() {
+      return data;
+    }
+  }
+
+  Variables EMPTY_VARIABLES = new Variables(Collections.<String, Object>emptyMap()) {
+  };
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ClassNames.kt
@@ -11,10 +11,12 @@ object ClassNames {
   val LIST: ClassName = ClassName.get(List::class.java)
   val COLLECTIONS: ClassName = ClassName.get(Collections::class.java)
   val ARRAYS: ClassName = ClassName.get(Arrays::class.java)
-  val QUERY: ClassName = ClassName.get(Query::class.java)
   val OBJECT: ClassName = ClassName.get(Object::class.java)
   val MAP: ClassName = ClassName.get(Map::class.java)
   val HASH_MAP: ClassName = ClassName.get(HashMap::class.java)
+  val STRING_BUILDER: ClassName = ClassName.get(StringBuilder::class.java)
+  val API_QUERY: ClassName = ClassName.get(Query::class.java)
+  val API_QUERY_VARIABLES: TypeName = ClassName.get("", "${API_QUERY.simpleName()}.Variables")
 
   fun parameterizedMapOf(firstTypeArgument: TypeName, secondTypeArgument: TypeName): TypeName =
       ParameterizedTypeName.get(MAP, firstTypeArgument, secondTypeArgument)

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/QueryVariablesTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/QueryVariablesTypeSpecBuilder.kt
@@ -11,29 +11,17 @@ class QueryVariablesTypeSpecBuilder(
   fun build(): TypeSpec {
     return TypeSpec.classBuilder(VARIABLES_CLASS_NAME)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-        .addDataField(CodeBlock.of(""))
+        .superclass(ClassNames.API_QUERY_VARIABLES)
         .addConstructor()
         .addVariablesAccessorMethods(variables)
         .addBuilder(variables)
         .build()
   }
 
-  private fun TypeSpec.Builder.addDataField(initializer: CodeBlock): TypeSpec.Builder {
-    return addField(FieldSpec.builder(
-        ClassNames.parameterizedMapOf(ClassNames.STRING, ClassNames.OBJECT),
-        VARIABLES_MAP_FIELD_NAME)
-        .addModifiers(Modifier.FINAL)
-        .initializer(initializer)
-        .build()
-    )
-  }
-
   private fun TypeSpec.Builder.addConstructor(): TypeSpec.Builder {
     return addMethod(MethodSpec.constructorBuilder()
-        .addParameter(ClassNames.parameterizedMapOf(ClassNames.STRING, ClassNames.OBJECT),
-            VARIABLES_MAP_FIELD_NAME)
-        .addStatement("this.\$L = \$T.unmodifiableMap(\$L)", VARIABLES_MAP_FIELD_NAME, ClassNames.COLLECTIONS,
-            VARIABLES_MAP_FIELD_NAME)
+        .addParameter(ClassNames.parameterizedMapOf(ClassNames.STRING, ClassNames.OBJECT), VARIABLES_MAP_FIELD_NAME)
+        .addStatement("super(\$L)", VARIABLES_MAP_FIELD_NAME)
         .build()
     )
   }
@@ -60,6 +48,16 @@ class QueryVariablesTypeSpecBuilder(
         .addDataField(CodeBlock.of("new \$T()", ClassNames.parameterizedHashMapOf(ClassNames.STRING, ClassNames.OBJECT)))
         .addVariableSetterMethods(variables)
         .addBuildMethod()
+        .build()
+    )
+  }
+
+  private fun TypeSpec.Builder.addDataField(initializer: CodeBlock): TypeSpec.Builder {
+    return addField(FieldSpec.builder(
+        ClassNames.parameterizedMapOf(ClassNames.STRING, ClassNames.OBJECT),
+        VARIABLES_MAP_FIELD_NAME)
+        .addModifiers(Modifier.FINAL)
+        .initializer(initializer)
         .build()
     )
   }
@@ -91,10 +89,10 @@ class QueryVariablesTypeSpecBuilder(
   }
 
   companion object {
-    val VARIABLES_CLASS_NAME: String = "Variables"
-    val VARIABLES_MAP_FIELD_NAME: String = "data"
-    val BUILDER_CLASS_NAME: String = "Builder"
-    val BUILD_METHOD_NAME: String = "build"
-    val VARIABLES_TYPE_NAME: TypeName = ClassName.get("", VARIABLES_CLASS_NAME)
+    private val VARIABLES_CLASS_NAME: String = "Variables"
+    private val VARIABLES_MAP_FIELD_NAME: String = "data"
+    private val BUILDER_CLASS_NAME: String = "Builder"
+    private val BUILD_METHOD_NAME: String = "build"
+    private val VARIABLES_TYPE_NAME: TypeName = ClassName.get("", VARIABLES_CLASS_NAME)
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/Util.kt
@@ -38,6 +38,7 @@ fun TypeSpec.resolveNestedTypeNameDuplication(reservedTypeNames: List<String>): 
       .addTypes(typeSpecs.map { typeSpec ->
         typeSpec.resolveNestedTypeNameDuplication(reservedTypeNames + typeSpecs.map { it.name })
       })
+      .addFields(fieldSpecs)
       .addSuperinterfaces(superinterfaces)
       .build()
 }

--- a/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollostack/compiler/ir/Fragment.kt
@@ -1,8 +1,11 @@
 package com.apollostack.compiler.ir
 
+import com.apollostack.compiler.ClassNames
 import com.apollostack.compiler.InterfaceTypeSpecBuilder
 import com.apollostack.compiler.resolveNestedTypeNameDuplication
+import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.TypeSpec
+import javax.lang.model.element.Modifier
 
 data class Fragment(
     val fragmentName: String,
@@ -15,6 +18,23 @@ data class Fragment(
 ) : CodeGenerator {
   /** Returns the Java interface that represents this Fragment object. */
   override fun toTypeSpec(): TypeSpec =
-      InterfaceTypeSpecBuilder().build(fragmentName.capitalize(), fields, fragmentSpreads, inlineFragments)
+      InterfaceTypeSpecBuilder().build(interfaceTypeName(), fields, fragmentSpreads, inlineFragments)
+          .toBuilder()
+          .addFragmentDefinition(this)
+          .build()
           .resolveNestedTypeNameDuplication(emptyList())
+
+  fun interfaceTypeName() = fragmentName.capitalize()
+
+  private fun TypeSpec.Builder.addFragmentDefinition(fragment: Fragment): TypeSpec.Builder {
+    return addField(FieldSpec.builder(ClassNames.STRING, FRAGMENT_DEFINITION_FIELD_NAME)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+        .initializer("\$S", fragment.source)
+        .build()
+    )
+  }
+
+  companion object {
+    val FRAGMENT_DEFINITION_FIELD_NAME = "FRAGMENT_DEFINITION"
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQueryExpected.java
@@ -3,9 +3,6 @@ package com.example.directives;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public final class TestQuery implements Query<Query.Variables> {
@@ -16,26 +13,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQueryExpected.java
@@ -1,15 +1,14 @@
 package com.example.directives;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -17,19 +16,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.enum_type;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -19,19 +18,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQueryExpected.java
@@ -3,8 +3,6 @@ package com.example.enum_type;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,26 +16,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/HeroDetailsExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/HeroDetailsExpected.java
@@ -7,6 +7,20 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface HeroDetails {
+  String FRAGMENT_DEFINITION = "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
+      + "}";
+
   @Nonnull String name();
 
   @Nonnull FriendsConnection friendsConnection();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.fragment_friends_connection;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -34,19 +33,29 @@ public final class TestQuery implements Query {
         + "}"
   ));
 
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return FRAGMENT_DEFINITIONS;
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQueryExpected.java
@@ -3,10 +3,6 @@ package com.example.fragment_friends_connection;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public final class TestQuery implements Query<Query.Variables> {
@@ -17,40 +13,18 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
-    "fragment HeroDetails on Character {\n"
-        + "  __typename\n"
-        + "  name\n"
-        + "  friendsConnection {\n"
-        + "    totalCount\n"
-        + "    edges {\n"
-        + "      node {\n"
-        + "        __typename\n"
-        + "        name\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}"
-  ));
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HeroDetails.FRAGMENT_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/HeroDetailsExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/HeroDetailsExpected.java
@@ -7,6 +7,24 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface HeroDetails {
+  String FRAGMENT_DEFINITION = "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
+      + "  ... on Droid {\n"
+      + "    name\n"
+      + "    primaryFunction\n"
+      + "  }\n"
+      + "}";
+
   @Nonnull String name();
 
   @Nonnull FriendsConnection friendsConnection();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQueryExpected.java
@@ -1,17 +1,16 @@
 package com.example.fragment_with_inline_fragment;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -41,19 +40,29 @@ public final class TestQuery implements Query {
         + "}"
   ));
 
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return FRAGMENT_DEFINITIONS;
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQueryExpected.java
@@ -3,9 +3,6 @@ package com.example.fragment_with_inline_fragment;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,44 +17,18 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
-    "fragment HeroDetails on Character {\n"
-        + "  __typename\n"
-        + "  name\n"
-        + "  friendsConnection {\n"
-        + "    totalCount\n"
-        + "    edges {\n"
-        + "      node {\n"
-        + "        __typename\n"
-        + "        name\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "  ... on Droid {\n"
-        + "    name\n"
-        + "    primaryFunction\n"
-        + "  }\n"
-        + "}"
-  ));
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HeroDetails.FRAGMENT_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.fragments_with_type_condition;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
@@ -34,19 +33,29 @@ public final class TestQuery implements Query {
         + "}"
   ));
 
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return FRAGMENT_DEFINITIONS;
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQueryExpected.java
@@ -3,10 +3,6 @@ package com.example.fragments_with_type_condition;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public final class TestQuery implements Query<Query.Variables> {
@@ -23,34 +19,19 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
-    "fragment HumanDetails on Human {\n"
-        + "  name\n"
-        + "  height\n"
-        + "}","fragment DroidDetails on Droid {\n"
-        + "  name\n"
-        + "  primaryFunction\n"
-        + "}"
-  ));
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HumanDetails.FRAGMENT_DEFINITION + "\n"
+   + DroidDetails.FRAGMENT_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQueryExpected.java
@@ -2,16 +2,15 @@ package com.example.hero_details;
 
 import com.apollostack.api.Query;
 import java.lang.Integer;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -28,19 +27,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQueryExpected.java
@@ -4,8 +4,6 @@ import com.apollostack.api.Query;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,26 +25,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQueryExpected.java
@@ -3,9 +3,6 @@ package com.example.hero_name;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -17,26 +14,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.hero_name;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -18,19 +17,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQueryExpected.java
@@ -4,8 +4,6 @@ import com.apollostack.api.Query;
 import java.lang.Float;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,26 +30,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQueryExpected.java
@@ -2,16 +2,15 @@ package com.example.inline_fragments_with_friends;
 
 import com.apollostack.api.Query;
 import java.lang.Float;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -33,19 +32,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQueryExpected.java
@@ -5,30 +5,41 @@ import java.lang.Boolean;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Long;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "";
+
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
 
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQueryExpected.java
@@ -7,34 +7,23 @@ import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQueryExpected.java
@@ -4,10 +4,7 @@ import com.apollostack.api.Query;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -19,26 +16,17 @@ public final class TestQuery implements Query<TestQuery.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final TestQuery.Variables variables;
 
   public TestQuery(TestQuery.Variables variables) {
     this.variables = variables;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQueryExpected.java
@@ -4,14 +4,14 @@ import com.apollostack.api.Query;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<TestQuery.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode, $includeName: Boolean!) {\n"
       + "  hero(episode: $episode) {\n"
       + "    __typename\n"
@@ -19,36 +19,36 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
-  private final Variables variables;
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
 
-  public TestQuery(@Nonnull Variables variables) {
+  private final String query;
+
+  private final TestQuery.Variables variables;
+
+  public TestQuery(TestQuery.Variables variables) {
     this.variables = variables;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
   }
 
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return variables.data;
-  }
-
-  public Variables variables() {
+  public TestQuery.Variables variables() {
     return variables;
   }
 
-  public static final class Variables {
-    final Map<String, Object> data;
-
+  public static final class Variables extends Query.Variables {
     Variables(Map<String, Object> data) {
-      this.data = Collections.unmodifiableMap(data);
+      super(data);
     }
 
     public @Nullable Episode episode() {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/HeroDetailsExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/HeroDetailsExpected.java
@@ -4,5 +4,10 @@ import java.lang.String;
 import javax.annotation.Nonnull;
 
 public interface HeroDetails {
+  String FRAGMENT_DEFINITION = "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "}";
+
   @Nonnull String name();
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.simple_fragment;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -25,19 +24,29 @@ public final class TestQuery implements Query {
         + "}"
   ));
 
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return FRAGMENT_DEFINITIONS;
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQueryExpected.java
@@ -3,10 +3,6 @@ package com.example.simple_fragment;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public final class TestQuery implements Query<Query.Variables> {
@@ -17,31 +13,18 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
-    "fragment HeroDetails on Character {\n"
-        + "  __typename\n"
-        + "  name\n"
-        + "}"
-  ));
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HeroDetails.FRAGMENT_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQueryExpected.java
@@ -2,16 +2,15 @@ package com.example.simple_inline_fragment;
 
 import com.apollostack.api.Query;
 import java.lang.Float;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query Query {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -25,19 +24,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQueryExpected.java
@@ -4,9 +4,6 @@ import com.apollostack.api.Query;
 import java.lang.Float;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -24,26 +21,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.two_heroes;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
@@ -22,19 +21,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQueryExpected.java
@@ -3,9 +3,6 @@ package com.example.two_heroes;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -21,26 +18,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQueryExpected.java
@@ -3,9 +3,6 @@ package com.example.two_heroes_unique;
 import com.apollostack.api.Query;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -22,26 +19,17 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQueryExpected.java
@@ -1,16 +1,15 @@
 package com.example.two_heroes_unique;
 
 import com.apollostack.api.Query;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
@@ -23,19 +22,31 @@ public final class TestQuery implements Query {
       + "  }\n"
       + "}";
 
+  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Collections.<String>emptyList());
+
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQueryExpected.java
@@ -2,17 +2,16 @@ package com.example.unique_type_name;
 
 import com.apollostack.api.Query;
 import java.lang.Float;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class TestQuery implements Query {
+public final class TestQuery implements Query<Query.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
@@ -51,19 +50,29 @@ public final class TestQuery implements Query {
         + "}"
   ));
 
+  private final String query;
+
+  private final Query.Variables variables;
+
+  public TestQuery() {
+    this.variables = Query.EMPTY_VARIABLES;
+    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
+    stringBuilder.append("\n");
+    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
+      stringBuilder.append("\n");
+      stringBuilder.append(fragmentDefinition);
+    }
+    query = stringBuilder.toString();
+  }
+
   @Override
   public String operationDefinition() {
-    return OPERATION_DEFINITION;
+    return query;
   }
 
   @Override
-  public List<String> fragmentDefinitions() {
-    return FRAGMENT_DEFINITIONS;
-  }
-
-  @Override
-  public Map<String, Object> variableDefinitions() {
-    return Collections.emptyMap();
+  public Query.Variables variables() {
+    return variables;
   }
 
   public interface Data extends Query.Data {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQueryExpected.java
@@ -4,9 +4,6 @@ import com.apollostack.api.Query;
 import java.lang.Float;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,40 +31,18 @@ public final class TestQuery implements Query<Query.Variables> {
       + "  }\n"
       + "}";
 
-  public static final List<String> FRAGMENT_DEFINITIONS = Collections.unmodifiableList(Arrays.asList(
-    "fragment HeroDetails on Character {\n"
-        + "  __typename\n"
-        + "  name\n"
-        + "  friendsConnection {\n"
-        + "    totalCount\n"
-        + "    edges {\n"
-        + "      node {\n"
-        + "        __typename\n"
-        + "        name\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}"
-  ));
-
-  private final String query;
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HeroDetails.FRAGMENT_DEFINITION;
 
   private final Query.Variables variables;
 
   public TestQuery() {
     this.variables = Query.EMPTY_VARIABLES;
-    StringBuilder stringBuilder = new StringBuilder(OPERATION_DEFINITION);
-    stringBuilder.append("\n");
-    for (String fragmentDefinition : FRAGMENT_DEFINITIONS) {
-      stringBuilder.append("\n");
-      stringBuilder.append(fragmentDefinition);
-    }
-    query = stringBuilder.toString();
   }
 
   @Override
-  public String operationDefinition() {
-    return query;
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
   }
 
   @Override

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -19,5 +19,8 @@ android {
 
 dependencies {
   compile dep.appcompat
+  compile project(":apollo-runtime")
+  compile project(":apollo-api")
+
   testCompile dep.junit
 }


### PR DESCRIPTION
Refactor `com.apollostack.api.Query`
Update how query been generated to comply with `Query` api

Example of generated code with arguments: https://github.com/apollostack/apollo-android/blob/f926d22c72904d2962ba68e7880c74a3d0ffe03c/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQueryExpected.java

Example of generated code with fragments: https://github.com/apollostack/apollo-android/blob/f926d22c72904d2962ba68e7880c74a3d0ffe03c/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQueryExpected.java

API usage example:
```
final Query query = new TestQuery(
        new TestQuery.Variables.Builder()
            .episode(Episode.JEDI)
            .includeName(true)
            .build()
    );
```

To get access to operation definition source and variables map for serialization purpose:
```
String definition = query.operationDefinition();
Map<String, Object> varialbles = query.variables().toMap();
```

Closes #51 

@felipecsl @martijnwalraven pls take a look