### PR TITLE
update gradle build tools and fix plugin errors

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollostack/android/gradle/ApolloClassgenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollostack/android/gradle/ApolloClassgenTask.groovy
@@ -1,6 +1,7 @@
 package com.apollostack.android.gradle
 
 import com.apollostack.compiler.GraphQLCompiler
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
@@ -8,7 +9,9 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 
 public class ApolloClassGenTask extends SourceTask {
   static final String NAME = "generate%sApolloClasses"
+  @Internal
   List<ApolloExtension> config
+  @Internal
   String variant
   @OutputDirectory
   File outputDir

--- a/apollo-gradle-plugin/src/main/groovy/com/apollostack/android/gradle/ApolloIRgenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollostack/android/gradle/ApolloIRgenTask.groovy
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets
 import com.moowork.gradle.node.task.NodeTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.util.PatternSet
 
@@ -13,7 +14,9 @@ public class ApolloIRGenTask extends NodeTask {
   protected static final String DEFAULT_SCHEMA_FILE_PATTERN = "**/schema.json"
   static final String NAME = "generate%sApolloIR"
 
+  @Internal
   String variant
+  @Internal
   List<ApolloExtension> config
   private List<String> possibleGraphQLPaths
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollostack/android/gradle/Utils.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollostack/android/gradle/Utils.groovy
@@ -17,8 +17,8 @@ private static def setupAndroidProject(Project project) {
 static def setupDefaultAndroidProject(Project project) {
   setupAndroidProject(project)
   project.android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
   }
   project.evaluate()
 }
@@ -26,8 +26,8 @@ static def setupDefaultAndroidProject(Project project) {
 static def setupAndroidProjectWithProductFlavours(Project project) {
   setupAndroidProject(project)
   project.android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
     productFlavors {
       demo {
         applicationIdSuffix ".demo"

--- a/apollo-gradle-plugin/src/test/groovy/com/apollostack/android/gradle/project/ApolloIRgenTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollostack/android/gradle/project/ApolloIRgenTaskSpec.groovy
@@ -38,4 +38,3 @@ class ApolloIRGenTaskSpec extends Specification {
     generateApolloIR.dependsOn.contains(project.tasks.getByName(String.format(ApolloIRGenTask.NAME, "Release")))
   }
 }
-

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -15,6 +15,12 @@ android {
     minSdkVersion 15
     targetSdkVersion 25
   }
+  
+  lintOptions {
+    textReport true
+    textOutput 'stdout'
+    ignore 'InvalidPackage'
+  }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ ext {
   buildToolsVersion = '25.0.1'
 
   dep = [
-      androidPlugin: 'com.android.tools.build:gradle:2.2.3',
+      androidPlugin: 'com.android.tools.build:gradle:2.3.0-beta1',
       supportAnnotations: 'com.android.support:support-annotations:25.0.1',
       compiletesting: 'com.google.testing.compile:compile-testing:0.10',
       javaPoet: 'com.squareup:javapoet:1.8.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip


### PR DESCRIPTION
Closes #60 

The `Internal` annotation was added to Gradle 3.1. It implies that those fields shouldn't be considered for incremental builds/up-to date checks.