### PR TITLE
apply apollo plugin for java modules

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloIRGenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloIRGenTask.groovy
@@ -38,7 +38,7 @@ public class ApolloIRGenTask extends NodeTask {
     variant = variantName
     config = extensionsConfig
     group = ApolloPlugin.TASK_GROUP
-    description = "Generate an IR file using apollo-codgen for ${variant.capitalize()} GraphQL queries"
+    description = "Generate an IR file using apollo-codegen for ${variant.capitalize()} GraphQL queries"
     dependsOn(ApolloCodeGenInstallTask.NAME)
 
     possibleGraphQLPaths = buildPossibleGraphQLPaths()

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
@@ -4,15 +4,8 @@ import org.gradle.api.Project;
 
 class ApolloPluginTestHelper {
 
-  private static def setupAndroidProject(Project project) {
-    def localProperties = new File("${project.projectDir.absolutePath}", "local.properties")
-    localProperties.write("sdk.dir=${androidHome()}")
-
-    def manifest = new File("${project.projectDir.absolutePath}/src/main", "AndroidManifest.xml")
-    manifest.getParentFile().mkdirs()
-    manifest.createNewFile()
-    manifest.write("<manifest package=\"com.example.apollographql\"/>")
-    project.apply plugin: 'com.android.application'
+  static def setupJavaProject(Project project) {
+    project.apply plugin: 'java'
   }
 
   static def setupDefaultAndroidProject(Project project) {
@@ -62,6 +55,17 @@ class ApolloPluginTestHelper {
           "SDK location not found. Define location with sdk.dir in the local.properties file or " +
               "with an ANDROID_HOME environment variable.")
     }
+  }
+
+  private static def setupAndroidProject(Project project) {
+    def localProperties = new File("${project.projectDir.absolutePath}", "local.properties")
+    localProperties.write("sdk.dir=${androidHome()}")
+
+    def manifest = new File("${project.projectDir.absolutePath}/src/main", "AndroidManifest.xml")
+    manifest.getParentFile().mkdirs()
+    manifest.createNewFile()
+    manifest.write("<manifest package=\"com.example.apollographql\"/>")
+    project.apply plugin: 'com.android.application'
   }
 
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -9,7 +9,7 @@ import com.moowork.gradle.node.NodePlugin
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
-class ApolloPluginSpec extends Specification {
+class ApolloAndroidPluginSpec extends Specification {
   def "creates an IRGen task under the apollo group for a default project"() {
     setup:
     def project = ProjectBuilder.builder().build()
@@ -24,10 +24,10 @@ class ApolloPluginSpec extends Specification {
 
     then:
     debugTask.group.equals(ApolloPlugin.TASK_GROUP)
-    debugTask.description.equals("Generate an IR file using apollo-codgen for Debug GraphQL queries")
+    debugTask.description.equals("Generate an IR file using apollo-codegen for Debug GraphQL queries")
 
     releaseTask.group.equals(ApolloPlugin.TASK_GROUP)
-    releaseTask.description.equals("Generate an IR file using apollo-codgen for Release GraphQL queries")
+    releaseTask.description.equals("Generate an IR file using apollo-codegen for Release GraphQL queries")
   }
 
   def "creates an IRGen task under the apollo group for a product-flavoured project"() {
@@ -46,10 +46,10 @@ class ApolloPluginSpec extends Specification {
       def releaseTask = project.tasks.getByName(String.format(ApolloIRGenTask.NAME, "${flavor}Release"))
 
       assert (debugTask.group) == ApolloPlugin.TASK_GROUP
-      assert (debugTask.description) == "Generate an IR file using apollo-codgen for " + flavor + "Debug GraphQL queries"
+      assert (debugTask.description) == "Generate an IR file using apollo-codegen for " + flavor + "Debug GraphQL queries"
 
       assert (releaseTask.group) == ApolloPlugin.TASK_GROUP
-      assert (releaseTask.description) == "Generate an IR file using apollo-codgen for " + flavor + "Release GraphQL queries"
+      assert (releaseTask.description) == "Generate an IR file using apollo-codegen for " + flavor + "Release GraphQL queries"
     }
   }
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloIRGenTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloIRGenTaskSpec.groovy
@@ -7,7 +7,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApolloIRGenTaskSpec extends Specification {
-  def "creates tasks for default project variants that depend on apolloCodgenInstall task"() {
+  def "creates tasks for default project variants that depend on apolloCodegenInstall task"() {
     setup:
     def project = ProjectBuilder.builder().build()
     ApolloPluginTestHelper.setupDefaultAndroidProject(project)

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloJavaPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloJavaPluginSpec.groovy
@@ -1,0 +1,83 @@
+package com.apollographql.android.gradle.unit
+
+import com.apollographql.android.gradle.*
+import com.moowork.gradle.node.NodePlugin
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ApolloJavaPluginSpec extends Specification {
+  def "creates an IRGen task under the apollo group"() {
+    setup:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupJavaProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    def mainTask = project.tasks.getByName(String.format(ApolloIRGenTask.NAME, "Main"))
+
+    then:
+    mainTask.group.equals(ApolloPlugin.TASK_GROUP)
+    mainTask.description.equals("Generate an IR file using apollo-codegen for Main GraphQL queries")
+  }
+
+  def "creates a ClassGen task under the apollo group"() {
+    setup:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupJavaProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    def mainTask = project.tasks.getByName(String.format(ApolloClassGenTask.NAME, "Main"))
+
+    then:
+    mainTask.group.equals(ApolloPlugin.TASK_GROUP)
+    mainTask.description.equals("Generate Android classes for Main GraphQL queries")
+  }
+
+  def "adds the node plugin to the project"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupJavaProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    project.plugins.hasPlugin(NodePlugin.class)
+  }
+
+  def "adds a graphql extension for all sourceSets"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupJavaProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    project.sourceSets.all { sourceSet ->
+      assert (sourceSet.extensions.findByName("graphql")) != null
+      assert (sourceSet.extensions.findByType(GraphQLExtension.class)) != null
+    }
+  }
+
+  def "adds apollo project-level extension"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupJavaProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    assert (project.extensions.findByName("apollo")) != null
+    assert (project.extensions.findByType(ApolloExtension.class)) != null
+  }
+}


### PR DESCRIPTION
Applies the apollo Gradle plugin to Gradle projects which have the java plugin applied.
Plus, some refactoring to the plugin class.

Needed for testing the `apollo-converters` module.