### PR TITLE
add an integration test fixture for non-referenced fragments

### DIFF
--- a/apollo-gradle-plugin/src/test/testProject/src/main/graphql/com/example/DroidDetailsSpeciesInfo.graphql
+++ b/apollo-gradle-plugin/src/test/testProject/src/main/graphql/com/example/DroidDetailsSpeciesInfo.graphql
@@ -1,0 +1,12 @@
+query DroidDetailsSpeciesInfo {
+  species(id: "c3BlY2llczoy") {
+    id
+    name
+    ...SpeciesInformation
+
+  }
+}
+
+fragment SpeciesInformation on Species{
+  classification
+}


### PR DESCRIPTION
This adds a query file with a fragment definition. It essentially aims to make
sure that the other query files that don't reference that fragment,
don't end up with a field referencing the fragment's definition in the operation
definition field.

In a separate PR because it required a new snapshot upload.

related to #108 and #107