### PR TITLE
add apollo-api dependency to gradle plugin

### DIFF
--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compileOnly gradleApi()
   compile localGroovy()
   compile project(':apollo-compiler')
+  compile project(':apollo-api')
   compile dep.gradleNodePlugin
   compile dep.androidPlugin
 

--- a/apollo-gradle-plugin/src/test/testProject/build.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
   compile 'com.jakewharton.auto.value:auto-value-annotations:1.3'
   compile 'com.ryanharter.auto.value:auto-value-moshi-annotations:0.4.2'
+  //TODO: remove after new snapshot
   compile 'com.apollographql.android:api:0.0.1-SNAPSHOT'
   compile 'io.reactivex.rxjava2:rxjava:2.0.3'
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   compile project(':apollo-converters:moshi')
   compile project(':apollo-converters:pojo')
   compile project(":apollo-runtime")
-  compile project(":apollo-api")
   compile 'io.reactivex.rxjava2:rxjava:2.0.3'
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
   compile 'com.squareup.retrofit2:adapter-rxjava2:2.2.0-SNAPSHOT'


### PR DESCRIPTION
Seems that the `apollo-api` dependency should be included with the plugin because the
`compile project (":apollo-api")` block under `apollo-compiler` isn't transitive(?) so we need to have it explicitly under the plugin.

The Gradle plugin needs that because the generated classes reference the api classes and it seems there won't be a use-case where `apollo-api` won't be needed.