### PR TITLE
add apollo-api dependency through the gradle plugin

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -3,6 +3,7 @@ package com.apollographql.android.gradle
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
+import com.apollographql.android.VersionKt
 import com.google.common.collect.Lists
 import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.NodePlugin
@@ -10,15 +11,11 @@ import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.DependencyResolutionListener
+import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
-
-import com.apollographql.android.gradle.GraphQLExtension
-import com.apollographql.android.gradle.ApolloClassGenTask
-import com.apollographql.android.gradle.ApolloIRGenTask
-import com.apollographql.android.gradle.ApolloExtension
-import com.apollographql.android.gradle.ApolloCodeGenInstallTask
 
 class ApolloPlugin implements Plugin<Project> {
   private static final String NODE_VERSION = "6.7.0"
@@ -40,7 +37,19 @@ class ApolloPlugin implements Plugin<Project> {
     setupNode()
     project.extensions.create(ApolloExtension.NAME, ApolloExtension)
     createSourceSetExtensions()
-    //TODO: add dependency on apollo-runtime once we have the jars on nexus
+
+    def compileDepSet = project.configurations.getByName("compile").dependencies
+    project.getGradle().addListener(new DependencyResolutionListener() {
+      @Override
+      void beforeResolve(ResolvableDependencies resolvableDependencies) {
+        //TODO: apollo-runtime dependency?
+        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
+        project.getGradle().removeListener(this)
+      }
+
+      @Override
+      void afterResolve(ResolvableDependencies resolvableDependencies) {}
+    })
 
     project.afterEvaluate {
       project.tasks.create(ApolloCodeGenInstallTask.NAME, ApolloCodeGenInstallTask.class)

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -42,7 +42,6 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        //TODO: apollo-runtime dependency?
         compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
         project.getGradle().removeListener(this)
       }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
@@ -66,6 +66,10 @@ class ApolloPluginTestHelper {
     manifest.createNewFile()
     manifest.write("<manifest package=\"com.example.apollographql\"/>")
     project.apply plugin: 'com.android.application'
+    project.repositories {
+      jcenter()
+      maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    }
   }
 
   public enum ProjectType {

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -1,10 +1,7 @@
 package com.apollographql.android.gradle.unit
 
-import com.apollographql.android.gradle.ApolloExtension
-import com.apollographql.android.gradle.ApolloIRGenTask
-import com.apollographql.android.gradle.ApolloPlugin
-import com.apollographql.android.gradle.ApolloPluginTestHelper
-import com.apollographql.android.gradle.GraphQLExtension
+import com.apollographql.android.VersionKt
+import com.apollographql.android.gradle.*
 import com.moowork.gradle.node.NodePlugin
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -110,5 +107,21 @@ class ApolloAndroidPluginSpec extends Specification {
     then:
     assert (project.extensions.findByName("apollo")) != null
     assert (project.extensions.findByType(ApolloExtension.class)) != null
+  }
+
+  def "adds apollo-api dependency"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    def apolloApi = project.configurations.getByName("compile").dependencies.find {
+      it.group == "com.apollographql.android" && it.name == "api"
+    }
+    assert apolloApi != null
   }
 }

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -32,12 +32,10 @@ android {
 
 repositories {
   jcenter()
-  maven { url "https://jitpack.io" }
   maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.apollographql.android:api:0.0.1-SNAPSHOT'
 }
 

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile project(':apollo-converters:moshi')
   compile project(':apollo-converters:pojo')
   compile project(":apollo-runtime")
+  //TODO: remove dependency after new snapshot release of the plugin
   compile project(":apollo-api")
   compile 'io.reactivex.rxjava2:rxjava:2.0.3'
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   compile project(':apollo-converters:moshi')
   compile project(':apollo-converters:pojo')
   compile project(":apollo-runtime")
-  //TODO: remove dependency after new snapshot release of the plugin
   compile project(":apollo-api")
   compile 'io.reactivex.rxjava2:rxjava:2.0.3'
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'


### PR DESCRIPTION
Dynamically adds the `apollo-api` dependency when configuring the apollo-plugin since it's needed by the generated classes (follows from #115)
