### PR TITLE
replace gson usages in the plugin with moshi

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -8,12 +8,14 @@ import java.io.IOException;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.internal.impldep.com.google.gson.stream.JsonReader;
 
 import com.google.common.collect.Lists;
-import com.google.gson.stream.JsonWriter;
 
 import com.moowork.gradle.node.npm.NpmTask;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+
+import okio.Okio;
 
 public class ApolloCodeGenInstallTask extends NpmTask {
   static final String NAME = "installApolloCodegen";
@@ -54,7 +56,7 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     }
     JsonReader jsonReader;
     try {
-      jsonReader = new JsonReader(new FileReader(packageFile));
+      jsonReader = JsonReader.of(Okio.buffer(Okio.source(packageFile)));
       jsonReader.beginObject();
 
       while (jsonReader.hasNext()) {
@@ -78,7 +80,8 @@ public class ApolloCodeGenInstallTask extends NpmTask {
    */
   private void writePackageFile(File apolloPackageFile) {
     try {
-      JsonWriter writer = new JsonWriter(new FileWriter(apolloPackageFile));
+      JsonWriter writer = JsonWriter.of(Okio.buffer(Okio.sink(apolloPackageFile)));
+
       writer.beginObject();
 
       writer.name("name").value("apollo-android");

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginBasicAndroidTest.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginBasicAndroidTest.groovy
@@ -38,7 +38,7 @@ class ApolloPluginBasicAndroidTest extends Specification {
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/Films.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/fragment/SpeciesInformation.java").isFile()
   }
-
+  
   def "installApolloCodegenTask gets outdated if node_modules directory is altered"() {
     setup: "a testProject with a deleted node_modules directory"
     FileUtils.deleteDirectory(new File(testProjectDir, "node_modules"))


### PR DESCRIPTION
This _should_ fix the following:

```
Caused by: org.gradle.api.tasks.TaskInstantiationException: 
Could not create task of type 'ApolloCodeGenInstallTask'.

Caused by: java.lang.NoClassDefFoundError: org/gradle/internal/impldep/com/google/gson/stream
/JsonReader
```
Unfortunately, only way to verify is through manual testing.